### PR TITLE
Add Nodejs Github action boilerplate with some modifications

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,0 +1,30 @@
+# This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
+
+name: Node.js CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: ['21.x']
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v3
+      with:
+        node-version: ${{ matrix.node-version }}
+        cache: 'npm'
+    - run: npm ci
+    - run: npm test

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -26,5 +26,5 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
-    - run: npm ci
+    # We don't have anything to install or build
     - run: npm test

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "spongebob-mocking-meme-sentence-generator",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "spongebob-mocking-meme-sentence-generator",
+      "version": "1.0.0",
+      "license": "ISC"
+    }
+  }
+}


### PR DESCRIPTION
- Narrowed Node to v21.x
- Removed build step
- Add `package-lock.json` to stop CI from breaking
  - Cache command requires it
  - But we don't have deps
  - Create an empty one anyway since we may add dependencies at some point