### PR TITLE
Add jsconfig to enforce standards

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,5 @@
+{
+    "compilerOptions": {
+        "checkJs": true
+    }
+}

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,6 +1,7 @@
 {
     "compilerOptions": {
         "checkJs": true,
+        "strictNullChecks": true,
         "target": "ES2015"
     }
 }

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,5 +1,6 @@
 {
     "compilerOptions": {
-        "checkJs": true
+        "checkJs": true,
+        "target": "ES2015"
     }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ function showMockMemeText(event) {
 
     const mockMemeText = generateSpongebobMockMemeText(userText);
 
+    /** @type {HTMLInputElement} */
     const outputTextField = document.querySelector("#spongebob-mock-formatted-text");
 
     outputTextField.value = mockMemeText;
@@ -18,6 +19,8 @@ copyToClipboardButton.addEventListener("click", handleOnCopyToClipboard)
 
 function handleOnCopyToClipboard() {
     // Get the meme formatted text that's shown to the user
+
+    /** @type {HTMLInputElement} */
     const { value: spongebobMockMemeText } = document.querySelector("#spongebob-mock-formatted-text");
 
     // Copy the text to their clipboard, user can paste it now

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ function showMockMemeText(event) {
 
     const mockMemeText = generateSpongebobMockMemeText(userText);
 
-    /** @type {HTMLInputElement} */
+    /** @type {HTMLInputElement | null} */
     const outputTextField = document.querySelector("#spongebob-mock-formatted-text");
 
     outputTextField.value = mockMemeText;
@@ -20,7 +20,7 @@ copyToClipboardButton.addEventListener("click", handleOnCopyToClipboard)
 function handleOnCopyToClipboard() {
     // Get the meme formatted text that's shown to the user
 
-    /** @type {HTMLInputElement} */
+    /** @type {HTMLInputElement | null} */
     const { value: spongebobMockMemeText } = document.querySelector("#spongebob-mock-formatted-text");
 
     // Copy the text to their clipboard, user can paste it now

--- a/src/spongebob-mock-meme-generate.js
+++ b/src/spongebob-mock-meme-generate.js
@@ -17,6 +17,10 @@ export function generateSpongebobMockMemeText(text, uppercaseOddsFromUser) {
     return lettersForMeme.join("");
 }
 
+/**
+ * @param {string} text
+ * @param {number} uppercaseOdds
+ */
 function uppercaseOrLowercaseRandomly(text, uppercaseOdds) {
 
     if (Math.random() <= uppercaseOdds) {

--- a/src/spongebob-mock-meme-generate.js
+++ b/src/spongebob-mock-meme-generate.js
@@ -1,6 +1,13 @@
 // Favor lowercase letters by default since we think it looks better
 export const UPPERCASE_ODDS_DEFAULT = .30
 
+/**
+ * 
+ * @param {string} text - Text to meme-ify
+ * @param {number} [uppercaseOddsFromUser] - Odds of a letter becoming uppercase
+ * 
+ * @returns {string} Text in the Spongebob mocking meme format: toTalLy LiKe tHiS
+ */
 export function generateSpongebobMockMemeText(text, uppercaseOddsFromUser) {
     const uppercaseOdds = uppercaseOddsFromUser ?? UPPERCASE_ODDS_DEFAULT;
 


### PR DESCRIPTION
- Add `jsconfig.json`
- Set `checkJs` to `true` to enforce to JSDoc types
- Set `target` to `ES2015` to allows strings to be spread into arrays
- Set `strictNullChecks` to `true`
- Add JSDoc comments to `generateSpongebobMockMemeText` and `uppercaseOrLowercaseRandomly` to type params and return type
- Add inline JSDoc comments to cast output text field as input element or `null`