### PR TITLE
Check types with typescript in CI

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -26,5 +26,7 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
-    # We don't have anything to install or build
+    # We don't have anything to build
+    - run: npm ci
+    - run: npm run type-check
     - run: npm test

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,23 @@
     "": {
       "name": "spongebob-mocking-meme-sentence-generator",
       "version": "1.0.0",
-      "license": "ISC"
+      "license": "ISC",
+      "devDependencies": {
+        "typescript": "^5.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "type": "module",
   "scripts": {
     "start": "npx http-server ./src",
-    "test": "node --test"
+    "test": "node --test",
+    "type-check": "tsc --noEmit -p jsconfig.json"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -20,5 +20,8 @@
   "bugs": {
     "url": "https://github.com/ChrisSMendoza/spongebob-mocking-meme-sentence-generator/issues"
   },
-  "homepage": "https://github.com/ChrisSMendoza/spongebob-mocking-meme-sentence-generator#readme"
+  "homepage": "https://github.com/ChrisSMendoza/spongebob-mocking-meme-sentence-generator#readme",
+  "devDependencies": {
+    "typescript": "^5.3.3"
+  }
 }


### PR DESCRIPTION
- Add `typescript`
- Install packages during CI
- Run type check before tests

Note, the failing step in this PR's CI run shows the type checks are working.