### PR TITLE
Fix type errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,6 +1,8 @@
 {
     "compilerOptions": {
         "checkJs": true,
+        "module": "NodeNext",
+        "moduleResolution": "nodenext",
         "strictNullChecks": true,
         "target": "ES2015"
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,17 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
+        "@types/node": "^20.10.6",
         "typescript": "^5.3.3"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.10.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.6.tgz",
+      "integrity": "sha512-Vac8H+NlRNNlAmDfGUP7b5h/KA+AtWIzuXy0E6OyP8f1tCLYAtPvKRRDJjAPqhpCb0t6U2j7/xqAuLEebW2kiw==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
       }
     },
     "node_modules/typescript": {
@@ -24,6 +34,12 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "spongebob-mock-meme-generate.js",
   "type": "module",
   "scripts": {
-    "start": "npx http-server ./src",
+    "start": "npx http-server ./src -c-1",
     "test": "node --test",
     "type-check": "tsc --noEmit -p jsconfig.json"
   },

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "homepage": "https://github.com/ChrisSMendoza/spongebob-mocking-meme-sentence-generator#readme",
   "devDependencies": {
+    "@types/node": "^20.10.6",
     "typescript": "^5.3.3"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -8,8 +8,7 @@ function showMockMemeText(event) {
 
     const mockMemeText = generateSpongebobMockMemeText(userText);
 
-    /** @type {HTMLInputElement | null} */
-    const outputTextField = document.querySelector("#spongebob-mock-formatted-text");
+    const outputTextField = getOutputTextElementOrThrow()
 
     outputTextField.value = mockMemeText;
 }
@@ -19,10 +18,24 @@ copyToClipboardButton?.addEventListener("click", handleOnCopyToClipboard)
 
 function handleOnCopyToClipboard() {
     // Get the meme formatted text that's shown to the user
-
-    /** @type {HTMLInputElement | null} */
-    const { value: spongebobMockMemeText } = document.querySelector("#spongebob-mock-formatted-text");
+    const { value: spongebobMockMemeText } = getOutputTextElementOrThrow()
 
     // Copy the text to their clipboard, user can paste it now
     navigator.clipboard.writeText(spongebobMockMemeText);
+}
+
+/**
+ *
+ * @returns {HTMLInputElement} Output text field
+ * @throws
+ */
+function getOutputTextElementOrThrow() {
+    /** @type {HTMLInputElement | null} */
+    const outputTextField = document.querySelector("#spongebob-mock-formatted-text");
+
+    if(outputTextField) {
+        return outputTextField;
+    }
+
+    throw Error("Output text field was not found in DOM with expected ID")
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 import { generateSpongebobMockMemeText } from "./spongebob-mock-meme-generate.js"
 
 const textInput = document.querySelector("#textInput");
-textInput.addEventListener("input", showMockMemeText);
+textInput?.addEventListener("input", showMockMemeText);
 
 function showMockMemeText(event) {
     const userText = event.target.value;
@@ -15,7 +15,7 @@ function showMockMemeText(event) {
 }
 
 const copyToClipboardButton = document.querySelector("#copy-to-clipboard-button");
-copyToClipboardButton.addEventListener("click", handleOnCopyToClipboard)
+copyToClipboardButton?.addEventListener("click", handleOnCopyToClipboard)
 
 function handleOnCopyToClipboard() {
     // Get the meme formatted text that's shown to the user


### PR DESCRIPTION
- Add option chaining for `addEventListener` calls since inputs may be null
- Add `getOutputTextElementOrThrow` to guarantee input element type
- Update `jsconfig.json` to use `NodeNext` so `node:*` imports are allowed
- Add Node types so TS doesn't complain about `node:*` import types

Unrelated changes:
- Remove caching from local server so refreshes load latest JS
- Add `.gitignore` to ignore `node_modules`
